### PR TITLE
:sparkles: Implement interviewer slot update endpoint (#74)

### DIFF
--- a/src/main/java/com/intellias/intellistart/interviewplanning/InterviewPlanningApplication.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/InterviewPlanningApplication.java
@@ -1,10 +1,10 @@
 package com.intellias.intellistart.interviewplanning;
 
+import org.modelmapper.Conditions;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -21,14 +21,19 @@ public class InterviewPlanningApplication {
   /**
    * Bean for getting ModelMapper to map entity to DTO and back.
    * modelMapper.getConfiguration().setAmbiguityIgnored(true) is used for determining whether
-   * destination properties that match more than one source property should be ignored/
-   *
+   * destination properties that match more than one source property should be ignored.
+   * modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull()) makes
+   * the model mapper to not map null properties into non-null properties of the destination
+   * object
+
    * @return ModelMapper
    */
   @Bean
   public ModelMapper modelMapper() {
     ModelMapper modelMapper = new ModelMapper();
     modelMapper.getConfiguration().setAmbiguityIgnored(true);
+
+    modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull());
     return modelMapper;
   }
 

--- a/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
@@ -72,9 +72,13 @@ public class InterviewerController {
       @PathVariable Long interviewerId, @PathVariable Long slotId) {
     InterviewerValidator.validateSlotWeekNum(slotDto.getWeekNum(), weekService.getNextWeekNum());
     InterviewerValidator.validateSlotDto(slotDto);
+    //voiding the interviewer id in dto, so it will not be mapped in the slot
+    slotDto.setInterviewerId(null);
 
     InterviewerSlot slot = interviewerService.getSlotById(slotId);
     InterviewerValidator.validateHasAccessToSlot(interviewerId, slot);
+    InterviewerValidator.validateSlotWeekNum(slot.getWeekNum(), weekService.getNextWeekNum());
+    mapper.map(slotDto, slot);
 
     InterviewerSlot updatedSlot = interviewerService.registerSlot(slot);
     InterviewerSlotDto updatedSlotDto = mapper.map(updatedSlot, InterviewerSlotDto.class);

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/exceptions/ForbiddenException.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/exceptions/ForbiddenException.java
@@ -1,0 +1,18 @@
+package com.intellias.intellistart.interviewplanning.util.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Forbidden HTTP Response exception.
+ */
+public class ForbiddenException extends InterviewApplicationException {
+
+  /**
+   * Constructor unauthorized access exception.
+   *
+   * @param message describing message about what lead to that exception
+   */
+  public ForbiddenException(String message) {
+    super("forbidden", HttpStatus.FORBIDDEN, message);
+  }
+}

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
@@ -1,9 +1,12 @@
 package com.intellias.intellistart.interviewplanning.util.validation;
 
+import com.intellias.intellistart.interviewplanning.controllers.dto.InterviewerSlotDto;
 import com.intellias.intellistart.interviewplanning.models.InterviewerSlot;
+import com.intellias.intellistart.interviewplanning.util.exceptions.ForbiddenException;
 import com.intellias.intellistart.interviewplanning.util.exceptions.InterviewApplicationException;
 import com.intellias.intellistart.interviewplanning.util.exceptions.InvalidSlotBoundariesException;
 import java.time.LocalTime;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -44,13 +47,38 @@ public class InterviewerValidator {
     }
   }
 
-  public static void validateSlot(InterviewerSlot slot) {
-    validateDuration(slot.getFrom(), slot.getTo());
+  /**
+   * Validates the all data in the slotDto dto.
+   * Throws exceptions if data in the slotDto is invalid, otherwise does nothing.
+   *
+   * @param slotDto slotDto to validate
+   * @throws InvalidSlotBoundariesException
+   *          if the time boundaries of the provided slotDto are invalid
+   */
+  public static void validateSlotDto(InterviewerSlotDto slotDto) {
+    validateDuration(slotDto.getTimeFrom(), slotDto.getTimeTo());
   }
 
   private static void validateDuration(LocalTime from, LocalTime to) {
     if (!UtilValidator.isValidTimeBoundaries(from, to)) {
       throw new InvalidSlotBoundariesException("Invalid slot time boundaries");
+    }
+  }
+
+  /**
+   * Validates that interviewer with provided {@code interviewerId}
+   * can access the provided {@code slot}.
+   *
+   * @param interviewerId id of the interviewer who tries to access the slot
+   * @param slot interviewer slot to which the interviewer tries to acquire the access
+   * @throws ForbiddenException if interviewer with provided {@code interviewerId}
+   *        has no access to the provided slot
+   */
+  public static void validateHasAccessToSlot(Long interviewerId, InterviewerSlot slot) {
+    Long interviewerIdFromSlot = slot.getInterviewer().getId();
+    if (!Objects.equals(interviewerId, interviewerIdFromSlot)) {
+      throw new ForbiddenException("Interviewer with id " + interviewerId
+          + " has no access to slot with id " + slot.getId());
     }
   }
 }


### PR DESCRIPTION
Implemented `POST /{interviewerId}/slots/{slotId} `endpoint, with
- validation of the fields of request body 
- validation that interviewer with interviewer id placed in path variable can only update their own slots, and do the update for the next week only
- validation that only slot from the next week can be updated

There is no automated tests for this endpoint, but I will implement them in one of my next PRs