### PR TITLE
:safety_vest: Implement validation of weekNum for InterviewerController endpoints (#139)

### DIFF
--- a/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
@@ -3,17 +3,21 @@ package com.intellias.intellistart.interviewplanning.controllers;
 import com.intellias.intellistart.interviewplanning.controllers.dto.InterviewerSlotDto;
 import com.intellias.intellistart.interviewplanning.models.Interviewer;
 import com.intellias.intellistart.interviewplanning.models.InterviewerSlot;
+import com.intellias.intellistart.interviewplanning.models.User;
 import com.intellias.intellistart.interviewplanning.models.enums.Role;
+import com.intellias.intellistart.interviewplanning.models.security.FacebookUserDetails;
 import com.intellias.intellistart.interviewplanning.services.InterviewerService;
 import com.intellias.intellistart.interviewplanning.services.WeekService;
 import com.intellias.intellistart.interviewplanning.util.validation.InterviewerValidator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +34,7 @@ public class InterviewerController {
 
   private final InterviewerService interviewerService;
   private final WeekService weekService;
-  public final ModelMapper mapper;
+  private final ModelMapper mapper;
 
   /**
    * Constructor for CoordinatorController.
@@ -44,15 +48,21 @@ public class InterviewerController {
   }
 
   /**
-   * Endpoint for adding a new interviewer time slot using interviewer id from request.
-   * Slot can be created only for next week (until Friday 00:00), or for weeks after the next week.
+   * Endpoint for adding a new interviewer time slot using interviewer id from request. Slot can be
+   * created only for next week (until Friday 00:00), or for weeks after the next week.
    *
    * @return added slot as DTO
    */
   @PostMapping("/{interviewerId}/slots")
+  @RolesAllowed("ROLE_INTERVIEWER")
   public ResponseEntity<InterviewerSlotDto> addSlot(
       @Valid @RequestBody InterviewerSlotDto slotDto,
-      @PathVariable Long interviewerId) {
+      @PathVariable Long interviewerId,
+      Authentication authentication) {
+    User authUser = ((FacebookUserDetails) authentication.getPrincipal()).getUser();
+    Interviewer authInterviewer = interviewerService.getInterviewerByUserId(authUser.getId());
+    InterviewerValidator.validateInterviewerIdMatch(authInterviewer.getId(), interviewerId);
+
     if (slotDto.getWeekNum() == null) {
       slotDto.setWeekNum(weekService.getNextWeekNum());
     }
@@ -67,24 +77,34 @@ public class InterviewerController {
   }
 
   /**
-   * Endpoint for updating Interviewer slot using id from request.
+   * Endpoint for updating Interviewer slot using id from request. Slot can be updated by the
+   * Coordinator (any slot registered at current week or next weeks), or by the Interviewer (only
+   * their own slots for next week until Friday 00:00 of current week, or for weeks after the next
+   * week, at any time).
    *
    * @return response status
    */
   @PostMapping("/{interviewerId}/slots/{slotId}")
+  @RolesAllowed({"ROLE_INTERVIEWER", "ROLE_COORDINATOR"})
   public ResponseEntity<InterviewerSlotDto> updateSlot(
       @Valid @RequestBody InterviewerSlotDto slotDto,
-      @PathVariable Long interviewerId, @PathVariable Long slotId) {
-    Role role = Role.INTERVIEWER; //TODO: get this from OAuth2
+      @PathVariable Long interviewerId, @PathVariable Long slotId,
+      Authentication authentication) {
+    User authUser = ((FacebookUserDetails) authentication.getPrincipal()).getUser();
+
+    if (authUser.getRole().equals(Role.INTERVIEWER)) {
+      Interviewer authInterviewer = interviewerService.getInterviewerByUserId(authUser.getId());
+      InterviewerValidator.validateInterviewerIdMatch(authInterviewer.getId(), interviewerId);
+    }
+
+    InterviewerValidator.validateSlotUpdateForDtoAndRole(slotDto, authUser.getRole(), weekService);
     //voiding the interviewer id in dto, so it will not be mapped in the slot
     slotDto.setInterviewerId(null);
 
-    InterviewerValidator.validateSlotUpdateForDtoAndRole(slotDto, role, weekService);
-
     InterviewerSlot slot = interviewerService.getSlotById(slotId);
     InterviewerValidator.validateHasAccessToSlot(interviewerId, slot);
-    InterviewerValidator.validateSlotUpdateForWeekNumAndRole(slot.getWeekNum(), role, weekService);
-
+    InterviewerValidator.validateSlotUpdateForWeekNumAndRole(
+        slot.getWeekNum(), authUser.getRole(), weekService);
     mapper.map(slotDto, slot);
 
     InterviewerSlot updatedSlot = interviewerService.registerSlot(slot);
@@ -98,6 +118,7 @@ public class InterviewerController {
    * @return response status
    */
   @GetMapping("/{interviewerId}/slots/current-week")
+  @RolesAllowed("ROLE_INTERVIEWER")
   public ResponseEntity<List<InterviewerSlotDto>> getCurrentWeekSlots(
       @PathVariable Long interviewerId) {
     List<InterviewerSlotDto> currentWeekSlots = interviewerService
@@ -115,6 +136,7 @@ public class InterviewerController {
    * @return response status
    */
   @GetMapping("/{interviewerId}/slots/next-week")
+  @RolesAllowed("ROLE_INTERVIEWER")
   public ResponseEntity<List<InterviewerSlotDto>> getNextWeekSlots(
       @PathVariable Long interviewerId) {
     List<InterviewerSlotDto> nextWeekSlots = interviewerService
@@ -132,9 +154,15 @@ public class InterviewerController {
    * @return response status
    */
   @PostMapping("/{interviewerId}/bookings/booking-limit")
+  @RolesAllowed("ROLE_INTERVIEWER")
   public ResponseEntity<Map<String, Integer>> setBookingLimit(
       @RequestBody Map<String, Integer> bookingLimitMap,
-      @PathVariable Long interviewerId) {
+      @PathVariable Long interviewerId,
+      Authentication authentication) {
+    User authUser = ((FacebookUserDetails) authentication.getPrincipal()).getUser();
+    Interviewer authInterviewer = interviewerService.getInterviewerByUserId(authUser.getId());
+    InterviewerValidator.validateInterviewerIdMatch(authInterviewer.getId(), interviewerId);
+
     Integer bookingLimit = bookingLimitMap.get("bookingLimit");
     InterviewerValidator.validateBookingLimit(bookingLimit);
 

--- a/src/main/java/com/intellias/intellistart/interviewplanning/controllers/dto/InterviewerSlotDto.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/controllers/dto/InterviewerSlotDto.java
@@ -21,7 +21,6 @@ import org.hibernate.validator.constraints.Range;
 @NoArgsConstructor
 public class InterviewerSlotDto implements Serializable {
 
-  @NotNull
   private Integer weekNum;
 
   @NotNull

--- a/src/main/java/com/intellias/intellistart/interviewplanning/services/WeekService.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/services/WeekService.java
@@ -68,6 +68,13 @@ public class WeekService {
   }
 
   /**
+   * Method for getting the current day of week.
+   */
+  public int getCurrentDayOfWeek() {
+    return getDayOfWeekFrom(getCurrentDate());
+  }
+
+  /**
    * Method for calculating day of week of an input date.
    */
   public static int getDayOfWeekFrom(LocalDate date) {

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/exceptions/InvalidWeekNumException.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/exceptions/InvalidWeekNumException.java
@@ -1,0 +1,18 @@
+package com.intellias.intellistart.interviewplanning.util.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Invalid week num exception, usually thrown when validation of the week num fails.
+ */
+public class InvalidWeekNumException extends InterviewApplicationException {
+
+  /**
+   * Constructor for invalid week num exception.
+   *
+   * @param message exception message
+   */
+  public InvalidWeekNumException(String message) {
+    super("invalid_weeknum", HttpStatus.BAD_REQUEST, message);
+  }
+}

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
@@ -74,7 +74,14 @@ public class InterviewerValidator {
   public static void validateSlotUpdateForDtoAndRole(InterviewerSlotDto slotDto, Role role,
       WeekService weekService) {
     validateSlotDuration(slotDto.getTimeFrom(), slotDto.getTimeTo());
+    validateSlotDtoWeekNumIsNotNull(slotDto.getWeekNum());
     validateSlotUpdateForWeekNumAndRole(slotDto.getWeekNum(), role, weekService);
+  }
+
+  private static void validateSlotDtoWeekNumIsNotNull(Integer weekNum) {
+    if (weekNum == null) {
+      throw new InvalidWeekNumException("Specify the weekNum for slot update.");
+    }
   }
 
   /**

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
@@ -181,4 +181,20 @@ public class InterviewerValidator {
       }
     }
   }
+
+  /**
+   * Validates that id of the interviewer authenticated in, matches the id of the interviewer in the
+   * request path. Throws an exception if it's not, otherwise does nothing.
+   *
+   * @param authInterviewerId id of the interviewer authenticated in
+   * @param pathInterviewerId id of the interviewer in the request path
+   * @throws ForbiddenException if the IDs are not matching (so Interviewer tries to access other
+   *                            Interviewer's data
+   */
+  public static void validateInterviewerIdMatch(Long authInterviewerId, Long pathInterviewerId) {
+    if (!pathInterviewerId.equals(authInterviewerId)) {
+      throw new ForbiddenException("Interviewer with id: " + authInterviewerId
+          + " tried to access the other interviewer (" + pathInterviewerId + ") data in request");
+    }
+  }
 }

--- a/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/util/validation/InterviewerValidator.java
@@ -2,9 +2,12 @@ package com.intellias.intellistart.interviewplanning.util.validation;
 
 import com.intellias.intellistart.interviewplanning.controllers.dto.InterviewerSlotDto;
 import com.intellias.intellistart.interviewplanning.models.InterviewerSlot;
+import com.intellias.intellistart.interviewplanning.models.enums.Role;
+import com.intellias.intellistart.interviewplanning.services.WeekService;
 import com.intellias.intellistart.interviewplanning.util.exceptions.ForbiddenException;
 import com.intellias.intellistart.interviewplanning.util.exceptions.InterviewApplicationException;
 import com.intellias.intellistart.interviewplanning.util.exceptions.InvalidSlotBoundariesException;
+import com.intellias.intellistart.interviewplanning.util.exceptions.InvalidWeekNumException;
 import com.intellias.intellistart.interviewplanning.util.exceptions.OverlappingSlotException;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -37,33 +40,90 @@ public class InterviewerValidator {
   }
 
   /**
-   * Validates that the given slotWeekNum is equal to nextWeekNum.
+   * Validates all the data in the slotDto dto for slot creation by interviewer. Throws exceptions
+   * if data in the slotDto is invalid, otherwise does nothing.
    *
-   * @param slotWeekNum week number of a slot
-   * @param nextWeekNum next week number
-   * @throws InterviewApplicationException slotWeekNum and nextWeekNum doesn't match
-   */
-  public static void validateSlotWeekNum(int slotWeekNum, int nextWeekNum) {
-    if (slotWeekNum != nextWeekNum) {
-      throw new InterviewApplicationException(
-          "bad_request", HttpStatus.BAD_REQUEST,
-          "Invalid weekNum: slot can be created only for next week: " + nextWeekNum);
-    }
-  }
-
-  /**
-   * Validates the all data in the slotDto dto. Throws exceptions if data in the slotDto is invalid,
-   * otherwise does nothing.
-   *
-   * @param slotDto slotDto to validate
+   * @param slotDto     slotDto to validate
+   * @param weekService weekService to get date parameters from
    * @throws InvalidSlotBoundariesException if the time boundaries of the provided slotDto are
    *                                        invalid
    */
-  public static void validateSlotDto(InterviewerSlotDto slotDto) {
-    validateDuration(slotDto.getTimeFrom(), slotDto.getTimeTo());
+  public static void validateSlotCreateForDtoWithService(InterviewerSlotDto slotDto,
+      WeekService weekService) {
+    validateSlotDuration(slotDto.getTimeFrom(), slotDto.getTimeTo());
+
+    int slotWeekNum = slotDto.getWeekNum();
+    validateIsNotPastWeek(slotWeekNum, weekService);
+    validateIsNotCurrentWeek(slotWeekNum, weekService);
+    validateIfNextWeekThenOnlyUntilFriday(slotWeekNum, weekService);
   }
 
-  private static void validateDuration(LocalTime from, LocalTime to) {
+  /**
+   * Validates all the data in the slotDto dto for slot updating by given role. Throws exceptions if
+   * data in the slotDto is invalid or given role is not allowed to update the slot, otherwise does
+   * nothing.
+   *
+   * @param slotDto     slotDto to validate
+   * @param role        role that performs the slot update
+   * @param weekService weekService to get date parameters from
+   * @throws InvalidSlotBoundariesException if the time boundaries of the provided slotDto are
+   *                                        invalid
+   * @throws ForbiddenException             if not allowed role tried to update the slot
+   */
+
+  public static void validateSlotUpdateForDtoAndRole(InterviewerSlotDto slotDto, Role role,
+      WeekService weekService) {
+    validateSlotDuration(slotDto.getTimeFrom(), slotDto.getTimeTo());
+    validateSlotUpdateForWeekNumAndRole(slotDto.getWeekNum(), role, weekService);
+  }
+
+  /**
+   * Validates that slot with the provided {@code slotWeekNum} can be updated by user with provided
+   * {@code role}. Throws exceptions if the validation fails.
+   *
+   * @param slotWeekNum slot weekNum to validate
+   * @param role        role that performs the slot update
+   * @param weekService weekService to get date parameters from
+   * @throws ForbiddenException if not allowed role tried to update the slot
+   */
+  public static void validateSlotUpdateForWeekNumAndRole(int slotWeekNum, Role role,
+      WeekService weekService) {
+    validateIsNotPastWeek(slotWeekNum, weekService);
+    switch (role) {
+      case COORDINATOR:
+        break;
+      case INTERVIEWER:
+        validateIsNotCurrentWeek(slotWeekNum, weekService);
+        validateIfNextWeekThenOnlyUntilFriday(slotWeekNum, weekService);
+        break;
+      default:
+        throw new ForbiddenException("Unexpected role for interviewer slot updating: " + role);
+    }
+  }
+
+  private static void validateIsNotCurrentWeek(int slotWeekNum, WeekService weekService) {
+    if (slotWeekNum == weekService.getCurrentWeekNum()) {
+      throw new InvalidWeekNumException("Cannot create or update slot for current weekNum.");
+    }
+  }
+
+  private static void validateIsNotPastWeek(int slotWeekNum, WeekService weekService) {
+    if (slotWeekNum < weekService.getCurrentWeekNum()) {
+      throw new InvalidWeekNumException("Cannot create or update slot for past weekNum.");
+    }
+  }
+
+  private static void validateIfNextWeekThenOnlyUntilFriday(int slotWeekNum,
+      WeekService weekService) {
+    if (slotWeekNum == weekService.getNextWeekNum()
+        && weekService.getCurrentDayOfWeek() > 4) {
+      throw new InvalidWeekNumException(
+          "Slot can be created or updated for next week only until Friday 00:00");
+    }
+  }
+
+
+  private static void validateSlotDuration(LocalTime from, LocalTime to) {
     if (!UtilValidator.isValidTimeBoundaries(from, to)) {
       throw new InvalidSlotBoundariesException("Invalid slot time boundaries");
     }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -3,3 +3,4 @@ spring.datasource.url=jdbc:h2:mem:test_db
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL95Dialect
 spring.sql.init.mode=never
+spring.main.allow-bean-definition-overriding=true

--- a/src/test/java/com/intellias/intellistart/interviewplanning/services/WeekServiceTest.java
+++ b/src/test/java/com/intellias/intellistart/interviewplanning/services/WeekServiceTest.java
@@ -16,8 +16,8 @@ class WeekServiceTest {
   @Test
   void getSameWeekNumsForSameDateTest() {
     LocalDate date = LocalDate.now(WeekService.ZONE_ID);
-    int expectedWeekNum = weekService.getWeekNumFrom(date);
-    int actualWeekNum = weekService.getWeekNumFrom(date);
+    int expectedWeekNum = WeekService.getWeekNumFrom(date);
+    int actualWeekNum = WeekService.getWeekNumFrom(date);
 
     assertThat(actualWeekNum).isEqualTo(expectedWeekNum);
   }
@@ -25,14 +25,14 @@ class WeekServiceTest {
   @Test
   void getCurrentWeekNumTest() {
     int actualWeekNum = weekService.getCurrentWeekNum();
-    int expectedWeekNum = weekService.getWeekNumFrom(LocalDate.now(WeekService.ZONE_ID));
+    int expectedWeekNum = WeekService.getWeekNumFrom(LocalDate.now(WeekService.ZONE_ID));
 
     //for avoiding the test failure on rare cases when the test
     //is performed on midnight of day, so two weekNums got different values
     //because got calculated in different days
     if (actualWeekNum != expectedWeekNum) {
       actualWeekNum = weekService.getCurrentWeekNum();
-      expectedWeekNum = weekService.getWeekNumFrom(LocalDate.now(WeekService.ZONE_ID));
+      expectedWeekNum = WeekService.getWeekNumFrom(LocalDate.now(WeekService.ZONE_ID));
     }
 
     assertThat(actualWeekNum).isEqualTo(expectedWeekNum);
@@ -41,7 +41,7 @@ class WeekServiceTest {
   @Test
   void getNextWeekNumTest() {
     int actualWeekNum = weekService.getNextWeekNum();
-    int expectedWeekNum = weekService.getWeekNumFrom(
+    int expectedWeekNum = WeekService.getWeekNumFrom(
         LocalDate.now(WeekService.ZONE_ID).plusDays(7));
 
     //for avoiding the test failure on rare cases when the test
@@ -49,7 +49,7 @@ class WeekServiceTest {
     //because got calculated in different days
     if (actualWeekNum != expectedWeekNum) {
       actualWeekNum = weekService.getNextWeekNum();
-      expectedWeekNum = weekService.getWeekNumFrom(
+      expectedWeekNum = WeekService.getWeekNumFrom(
           LocalDate.now(WeekService.ZONE_ID).plusDays(7));
     }
 
@@ -61,8 +61,8 @@ class WeekServiceTest {
     LocalDate date1 = LocalDate.of(2022, 11, 24);
     LocalDate date2 = LocalDate.of(2022, 11, 25);
 
-    int actualWeekNum = weekService.getWeekNumFrom(date1);
-    int expectedWeekNum = weekService.getWeekNumFrom(date2);
+    int actualWeekNum = WeekService.getWeekNumFrom(date1);
+    int expectedWeekNum = WeekService.getWeekNumFrom(date2);
 
     assertThat(actualWeekNum).isEqualTo(expectedWeekNum);
   }
@@ -72,8 +72,8 @@ class WeekServiceTest {
     LocalDate date1 = LocalDate.of(2022, 11, 23); //sunday
     LocalDate date2 = LocalDate.of(2022, 11, 24); //monday
 
-    int actualWeekNum = weekService.getWeekNumFrom(date1);
-    int expectedWeekNum = weekService.getWeekNumFrom(date2);
+    int actualWeekNum = WeekService.getWeekNumFrom(date1);
+    int expectedWeekNum = WeekService.getWeekNumFrom(date2);
 
     assertThat(actualWeekNum).isEqualTo(expectedWeekNum);
   }
@@ -85,8 +85,8 @@ class WeekServiceTest {
     LocalDate date1 = LocalDate.of(2019, 12, 31);
     LocalDate date2 = LocalDate.of(2020, 1, 1);
 
-    int prevYearWeekNum = weekService.getWeekNumFrom(date1);
-    int nextYearWeekNum = weekService.getWeekNumFrom(date2);
+    int prevYearWeekNum = WeekService.getWeekNumFrom(date1);
+    int nextYearWeekNum = WeekService.getWeekNumFrom(date2);
     int actualYear = prevYearWeekNum / 100;
 
     assertThat(prevYearWeekNum).isEqualTo(nextYearWeekNum);
@@ -100,8 +100,8 @@ class WeekServiceTest {
     LocalDate date1 = LocalDate.of(2026, 12, 31); //saturday
     LocalDate date2 = LocalDate.of(2027, 1, 1);   //monday
 
-    int prevYearWeekNum = weekService.getWeekNumFrom(date1);
-    int nextYearWeekNum = weekService.getWeekNumFrom(date2);
+    int prevYearWeekNum = WeekService.getWeekNumFrom(date1);
+    int nextYearWeekNum = WeekService.getWeekNumFrom(date2);
     int actualYear = prevYearWeekNum / 100;
 
     assertThat(prevYearWeekNum).isEqualTo(nextYearWeekNum);
@@ -118,5 +118,13 @@ class WeekServiceTest {
     assertThat(date).isEqualTo(WeekService.getDateFromWeekAndDay(weekNum, dayOfWeek));
     assertThat(dateIsNotCorrect).isNotEqualTo(
         WeekService.getDateFromWeekAndDay(weekNum, dayOfWeek));
+  }
+
+  @Test
+  void getCurrentDayOfWeekTest() {
+    int actualDayOfWeek = weekService.getCurrentDayOfWeek();
+    int expectedDayOfWeek = LocalDate.now(WeekService.ZONE_ID).getDayOfWeek().getValue();
+
+    assertThat(actualDayOfWeek).isEqualTo(expectedDayOfWeek);
   }
 }


### PR DESCRIPTION
Refactor add slot endpoint:

- slot for the next week can only be created until Friday 00:00
- slot can be created for weeks after the next week if weekNum is provided in request body. weekNum must be validated in this case

Refactor update slot endpoint:

- Slot can be edited only for next week and weeks after next week
- Cover the newly implemented validation with tests

Also created stubs in InterviewerValidator to implement the #134. For now, the role in update interviewer slot endpoint is hardcoded to interviewer. I will need some time to learn about the newly implemented OAuth2 module, how to use it in endpoints and how to test it properly.