### PR TITLE
:ambulance: Hot fix of Get All Interviewers endpoint

### DIFF
--- a/src/main/java/com/intellias/intellistart/interviewplanning/controllers/CoordinatorController.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/controllers/CoordinatorController.java
@@ -179,6 +179,7 @@ public class CoordinatorController {
     List<InterviewerDto> interviewerDtos = interviewerService
         .getAllInterviewers()
         .stream()
+        .filter(i -> i.getUser().getRole() == Role.INTERVIEWER)
         .map(interviewer -> mapper.map(interviewer, InterviewerDto.class))
         .collect(Collectors.toList());
 


### PR DESCRIPTION
The endpoint returned Interviewers that were revoked, so fixed it.