### PR TITLE
:ambulance: Hotfix the GET interviewer slots endpoints

### DIFF
--- a/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
+++ b/src/main/java/com/intellias/intellistart/interviewplanning/controllers/InterviewerController.java
@@ -126,10 +126,11 @@ public class InterviewerController {
       @PathVariable Long interviewerId,
       Authentication authentication) {
     Long authUserId = ((FacebookUserDetails) authentication.getPrincipal()).getUser().getId();
+    Long authInterviewerId = interviewerService.getInterviewerByUserId(authUserId).getId();
     interviewerValidator.validateUserIdMatch(authUserId, interviewerId);
 
     List<InterviewerSlotForm> currentWeekSlots = interviewerService
-        .getSlotsForIdAndWeek(interviewerId, weekService.getCurrentWeekNum())
+        .getSlotsForIdAndWeek(authInterviewerId, weekService.getCurrentWeekNum())
         .stream()
         .map(slot -> mapper.map(slot, InterviewerSlotForm.class))
         .collect(Collectors.toList());
@@ -149,10 +150,11 @@ public class InterviewerController {
       @PathVariable Long interviewerId,
       Authentication authentication) {
     Long authUserId = ((FacebookUserDetails) authentication.getPrincipal()).getUser().getId();
+    Long authInterviewerId = interviewerService.getInterviewerByUserId(authUserId).getId();
     interviewerValidator.validateUserIdMatch(authUserId, interviewerId);
 
     List<InterviewerSlotForm> nextWeekSlots = interviewerService
-        .getSlotsForIdAndWeek(interviewerId, weekService.getNextWeekNum())
+        .getSlotsForIdAndWeek(authInterviewerId, weekService.getNextWeekNum())
         .stream()
         .map(slot -> mapper.map(slot, InterviewerSlotForm.class))
         .collect(Collectors.toList());


### PR DESCRIPTION
While changing the logic of InterviewerController endpoints to work with UserId instead of InterviewerId, accidentally broke GET endpoints, so they`re trying to get the slots of the interviewer by user id instead of interviewer id. Fixed that in this commit. Apologies. 